### PR TITLE
update gradle version and apply latest addon gradle scripts to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.iml
 *.ipr
 *.iws
+.idea/
 
 build/
 gradle-app.setting

--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,25 @@
 // this bit of complexity is to pull down the main build script from the alclabs maven repository
 // and then apply it.
 configurations { gradleScript }
-repositories { mavenRepo url: 'http://repo.alcshare.com' }
-dependencies { gradleScript group: 'com.alcshare', name: 'addon-gradle', ext: 'gradle', version: '1.1' }
+repositories { maven { url 'http://repo.alcshare.com'} }
+dependencies { gradleScript group: 'com.alcshare', name: 'addon-gradle', ext: 'gradle', version: '1.7' }
 apply from: configurations.gradleScript.resolve().iterator().next()
 
 signAddon() // request for this add-on to be signed (so we can specify that no license requirements should be enforced)
-
 info {
-  name = 'Modstat'
-  description = 'Gather, parse, and find errors in module status reports'
-  version = '1.1.0'
-  vendor = 'ALC Labs'
-
-  // make this add-on function regardless of the license
-  licenseRequirements {}
+    name = 'Modstat'
+    description = 'Gather, parse, and find errors in module status reports'
+    version = '1.1.0'
+    vendor = 'ALC Labs' // make this add-on function regardless of the license
+    licenseRequirements {}
 }
-
+apply plugin: 'groovy'
 dependencies {
     compile 'commons-io:commons-io:1.4'
     compile 'org.json:json:20080701'
     compile 'com.intellij:annotations:7.0.3'
 
-    groovy      'org.codehaus.groovy:groovy-all:1.8.6'
+    compile     'org.codehaus.groovy:groovy-all:1.8.6'
 
     testCompile 'org.spockframework:spock-core:0.6-groovy-1.8'
     testCompile 'junit:junit:4.8.1'

--- a/wrapper/gradle-wrapper.properties
+++ b/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.0-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-3.1-bin.zip


### PR DESCRIPTION
when I last forked the repo I had issues building and running with IntelliJ due to old gradle version.  These changes correct for that and use our current build scripts.